### PR TITLE
Exit early on long pruning-related process when process is exiting

### DIFF
--- a/consensus/core/src/errors/pruning.rs
+++ b/consensus/core/src/errors/pruning.rs
@@ -56,6 +56,9 @@ pub enum PruningImportError {
 
     #[error("pruning import data lead to validation rule error")]
     PruningImportRuleError(#[from] RuleError),
+
+    #[error("process exit was initiated while validating pruning point proof")]
+    PruningValidationInterrupted,
 }
 
 pub type PruningImportResult<T> = std::result::Result<T, PruningImportError>;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -354,7 +354,7 @@ impl Consensus {
     }
 
     pub fn signal_exit(&self) {
-        self.is_consensus_exiting.store(true, Ordering::SeqCst);
+        self.is_consensus_exiting.store(true, Ordering::Relaxed);
         self.block_sender.send(BlockProcessingMessage::Exit).unwrap();
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -74,12 +74,15 @@ use kaspa_hashes::Hash;
 use kaspa_muhash::MuHash;
 use kaspa_txscript::caches::TxScriptCacheCounters;
 
-use std::thread::{self, JoinHandle};
 use std::{
     future::Future,
     iter::once,
     ops::Deref,
     sync::{atomic::Ordering, Arc},
+};
+use std::{
+    sync::atomic::AtomicBool,
+    thread::{self, JoinHandle},
 };
 use tokio::sync::oneshot;
 
@@ -122,6 +125,9 @@ pub struct Consensus {
 
     // Other
     creation_timestamp: u64,
+
+    // Signals
+    is_process_exiting: Arc<AtomicBool>,
 }
 
 impl Deref for Consensus {
@@ -144,6 +150,7 @@ impl Consensus {
     ) -> Self {
         let params = &config.params;
         let perf_params = &config.perf;
+        let is_process_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         //
         // Storage layer
@@ -249,8 +256,15 @@ impl Consensus {
             counters.clone(),
         ));
 
-        let pruning_processor =
-            Arc::new(PruningProcessor::new(pruning_receiver, db.clone(), &storage, &services, pruning_lock.clone(), config.clone()));
+        let pruning_processor = Arc::new(PruningProcessor::new(
+            pruning_receiver,
+            db.clone(),
+            &storage,
+            &services,
+            pruning_lock.clone(),
+            config.clone(),
+            is_process_exiting.clone(),
+        ));
 
         // Ensure the relations stores are initialized
         header_processor.init();
@@ -278,6 +292,7 @@ impl Consensus {
             counters,
             config,
             creation_timestamp,
+            is_process_exiting,
         }
     }
 
@@ -333,6 +348,7 @@ impl Consensus {
     }
 
     pub fn signal_exit(&self) {
+        self.is_process_exiting.store(true, Ordering::SeqCst);
         self.block_sender.send(BlockProcessingMessage::Exit).unwrap();
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -127,7 +127,7 @@ pub struct Consensus {
     creation_timestamp: u64,
 
     // Signals
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl Deref for Consensus {
@@ -150,7 +150,7 @@ impl Consensus {
     ) -> Self {
         let params = &config.params;
         let perf_params = &config.perf;
-        let is_process_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let is_consensus_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         //
         // Storage layer
@@ -162,8 +162,13 @@ impl Consensus {
         // Services and managers
         //
 
-        let services =
-            ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters, is_process_exiting.clone());
+        let services = ConsensusServices::new(
+            db.clone(),
+            storage.clone(),
+            config.clone(),
+            tx_script_cache_counters,
+            is_consensus_exiting.clone(),
+        );
 
         //
         // Processor channels
@@ -264,7 +269,7 @@ impl Consensus {
             &services,
             pruning_lock.clone(),
             config.clone(),
-            is_process_exiting.clone(),
+            is_consensus_exiting.clone(),
         ));
 
         // Ensure the relations stores are initialized
@@ -293,7 +298,7 @@ impl Consensus {
             counters,
             config,
             creation_timestamp,
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -349,7 +354,7 @@ impl Consensus {
     }
 
     pub fn signal_exit(&self) {
-        self.is_process_exiting.store(true, Ordering::SeqCst);
+        self.is_consensus_exiting.store(true, Ordering::SeqCst);
         self.block_sender.send(BlockProcessingMessage::Exit).unwrap();
     }
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -162,7 +162,8 @@ impl Consensus {
         // Services and managers
         //
 
-        let services = ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters);
+        let services =
+            ConsensusServices::new(db.clone(), storage.clone(), config.clone(), tx_script_cache_counters, is_process_exiting.clone());
 
         //
         // Processor channels

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use itertools::Itertools;
 use kaspa_txscript::caches::TxScriptCacheCounters;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 
 pub type DbGhostdagManager =
     GhostdagManager<DbGhostdagStore, MTRelationsService<DbRelationsStore>, MTReachabilityService<DbReachabilityStore>, DbHeadersStore>;
@@ -71,6 +71,7 @@ impl ConsensusServices {
         storage: Arc<ConsensusStorage>,
         config: Arc<Config>,
         tx_script_cache_counters: Arc<TxScriptCacheCounters>,
+        is_process_exiting: Arc<AtomicBool>,
     ) -> Arc<Self> {
         let params = &config.params;
 
@@ -185,6 +186,7 @@ impl ConsensusServices {
             params.pruning_proof_m,
             params.anticone_finalization_depth(),
             params.ghostdag_k,
+            is_process_exiting,
         ));
 
         let sync_manager = SyncManager::new(

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -71,7 +71,7 @@ impl ConsensusServices {
         storage: Arc<ConsensusStorage>,
         config: Arc<Config>,
         tx_script_cache_counters: Arc<TxScriptCacheCounters>,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Arc<Self> {
         let params = &config.params;
 
@@ -186,7 +186,7 @@ impl ConsensusServices {
             params.pruning_proof_m,
             params.anticone_finalization_depth(),
             params.ghostdag_k,
-            is_process_exiting,
+            is_consensus_exiting,
         ));
 
         let sync_manager = SyncManager::new(

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -345,7 +345,7 @@ impl PruningProcessor {
             if lock_acquire_time.elapsed() > Duration::from_millis(5) {
                 drop(reachability_read);
                 // An exit signal was received. Exit from this long running process.
-                if self.is_consensus_exiting.load(Ordering::SeqCst) {
+                if self.is_consensus_exiting.load(Ordering::Relaxed) {
                     drop(prune_guard);
                     info!("Header and Block pruning interrupted: Process is exiting");
                     return;

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -45,7 +45,10 @@ use rocksdb::WriteBatch;
 use std::{
     collections::VecDeque,
     ops::Deref,
-    sync::{Arc, atomic::{AtomicBool, Ordering}},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -81,7 +81,7 @@ pub struct PruningProcessor {
     config: Arc<Config>,
 
     // Signals
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl Deref for PruningProcessor {
@@ -100,7 +100,7 @@ impl PruningProcessor {
         services: &Arc<ConsensusServices>,
         pruning_lock: SessionLock,
         config: Arc<Config>,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             receiver,
@@ -112,7 +112,7 @@ impl PruningProcessor {
             pruning_proof_manager: services.pruning_proof_manager.clone(),
             pruning_lock,
             config,
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -345,7 +345,7 @@ impl PruningProcessor {
             if lock_acquire_time.elapsed() > Duration::from_millis(5) {
                 drop(reachability_read);
                 // An exit signal was received. Exit from this long running process.
-                if self.is_process_exiting.load(Ordering::SeqCst) {
+                if self.is_consensus_exiting.load(Ordering::SeqCst) {
                     drop(prune_guard);
                     info!("Header and Block pruning interrupted: Process is exiting");
                     return;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -441,7 +441,7 @@ impl PruningProofManager {
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
             // Before processing this level, check if the process is exiting so we can end early
-            if self.is_consensus_exiting.load(Ordering::SeqCst) {
+            if self.is_consensus_exiting.load(Ordering::Relaxed) {
                 return Err(PruningImportError::PruningValidationInterrupted);
             }
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -3,7 +3,10 @@ use std::{
     collections::{hash_map::Entry, BinaryHeap},
     collections::{hash_map::Entry::Vacant, VecDeque},
     ops::{Deref, DerefMut},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use itertools::Itertools;
@@ -115,6 +118,8 @@ pub struct PruningProofManager {
     pruning_proof_m: u64,
     anticone_finalization_depth: u64,
     ghostdag_k: KType,
+
+    is_process_exiting: Arc<AtomicBool>,
 }
 
 impl PruningProofManager {
@@ -132,6 +137,7 @@ impl PruningProofManager {
         pruning_proof_m: u64,
         anticone_finalization_depth: u64,
         ghostdag_k: KType,
+        is_process_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             db,
@@ -162,6 +168,8 @@ impl PruningProofManager {
             pruning_proof_m,
             anticone_finalization_depth,
             ghostdag_k,
+
+            is_process_exiting,
         }
     }
 
@@ -432,6 +440,11 @@ impl PruningProofManager {
 
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
+            // Before processing this level, check if the process is exiting so we can end early
+            if self.is_process_exiting.load(Ordering::SeqCst) {
+                return Err(PruningImportError::PruningValidationInterrupted);
+            }
+
             info!("Validating level {level} from the pruning point proof ({} headers)", proof[level as usize].len());
             let level_idx = level as usize;
             let mut selected_tip = None;

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -119,7 +119,7 @@ pub struct PruningProofManager {
     anticone_finalization_depth: u64,
     ghostdag_k: KType,
 
-    is_process_exiting: Arc<AtomicBool>,
+    is_consensus_exiting: Arc<AtomicBool>,
 }
 
 impl PruningProofManager {
@@ -137,7 +137,7 @@ impl PruningProofManager {
         pruning_proof_m: u64,
         anticone_finalization_depth: u64,
         ghostdag_k: KType,
-        is_process_exiting: Arc<AtomicBool>,
+        is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
             db,
@@ -169,7 +169,7 @@ impl PruningProofManager {
             anticone_finalization_depth,
             ghostdag_k,
 
-            is_process_exiting,
+            is_consensus_exiting,
         }
     }
 
@@ -441,7 +441,7 @@ impl PruningProofManager {
         let mut selected_tip_by_level = vec![None; self.max_block_level as usize + 1];
         for level in (0..=self.max_block_level).rev() {
             // Before processing this level, check if the process is exiting so we can end early
-            if self.is_process_exiting.load(Ordering::SeqCst) {
+            if self.is_consensus_exiting.load(Ordering::SeqCst) {
                 return Err(PruningImportError::PruningValidationInterrupted);
             }
 


### PR DESCRIPTION
Long running processes that will now exit early:
- validate_pruning_point_proof
- pruning processor's header processing