### PR TITLE
Split logging of performance metrics into better readable lines

### DIFF
--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -154,8 +154,18 @@ impl Runtime {
 
         let log_dir = get_log_dir(args);
 
+        let log_level = if args.perf_metrics {
+            if args.log_level.is_empty() {
+                "kaspa_perf_monitor::counters=trace".to_string()
+            } else {
+                format!("{},kaspa_perf_monitor::counters=trace", args.log_level)
+            }
+        } else {
+            args.log_level.clone()
+        };
+
         // Initialize the logger
-        kaspa_core::log::init_logger(log_dir.as_deref(), &args.log_level);
+        kaspa_core::log::init_logger(log_dir.as_deref(), &log_level);
 
         Self { log_dir: log_dir.map(|log_dir| log_dir.to_owned()) }
     }

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -6,7 +6,9 @@ use kaspa_consensus_core::{
     errors::config::{ConfigError, ConfigResult},
 };
 use kaspa_consensus_notify::{root::ConsensusNotificationRoot, service::NotifyService};
-use kaspa_core::{core::Core, info, trace};
+#[cfg(feature = "heap")]
+use kaspa_core::trace;
+use kaspa_core::{core::Core, info};
 use kaspa_core::{kaspad_env::version, task::tick::TickService};
 use kaspa_grpc_server::service::GrpcService;
 use kaspa_rpc_service::service::RpcCoreService;
@@ -29,7 +31,7 @@ use kaspa_mining::{
 };
 use kaspa_p2p_flows::{flow_context::FlowContext, service::P2pService};
 
-use kaspa_perf_monitor::builder::Builder as PerfMonitorBuilder;
+use kaspa_perf_monitor::{builder::Builder as PerfMonitorBuilder, counters::CountersSnapshot};
 use kaspa_utxoindex::{api::UtxoIndexProxy, UtxoIndex};
 use kaspa_wrpc_server::service::{Options as WrpcServerOptions, ServerCounters as WrpcServerCounters, WrpcEncoding, WrpcService};
 
@@ -377,8 +379,8 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         .with_fetch_interval(Duration::from_secs(args.perf_metrics_interval_sec))
         .with_tick_service(tick_service.clone());
     let perf_monitor = if args.perf_metrics {
-        let cb = move |counters| {
-            trace!("[{}] metrics: {:?}", kaspa_perf_monitor::SERVICE_NAME, counters);
+        let cb = move |counters: CountersSnapshot| {
+            counters.log_metrics(kaspa_perf_monitor::SERVICE_NAME);
             #[cfg(feature = "heap")]
             trace!("[{}] heap stats: {:?}", kaspa_perf_monitor::SERVICE_NAME, dhat::HeapStats::get());
         };

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -154,18 +154,8 @@ impl Runtime {
 
         let log_dir = get_log_dir(args);
 
-        let log_level = if args.perf_metrics {
-            if args.log_level.is_empty() {
-                "kaspa_perf_monitor::counters=trace".to_string()
-            } else {
-                format!("{},kaspa_perf_monitor::counters=trace", args.log_level)
-            }
-        } else {
-            args.log_level.clone()
-        };
-
         // Initialize the logger
-        kaspa_core::log::init_logger(log_dir.as_deref(), &log_level);
+        kaspa_core::log::init_logger(log_dir.as_deref(), &args.log_level);
 
         Self { log_dir: log_dir.map(|log_dir| log_dir.to_owned()) }
     }

--- a/kaspad/src/daemon.rs
+++ b/kaspad/src/daemon.rs
@@ -390,7 +390,7 @@ do you confirm? (answer y/n or pass --yes to the Kaspad command line to confirm 
         .with_tick_service(tick_service.clone());
     let perf_monitor = if args.perf_metrics {
         let cb = move |counters: CountersSnapshot| {
-            counters.log_metrics(kaspa_perf_monitor::SERVICE_NAME);
+            info!("{}", counters);
             #[cfg(feature = "heap")]
             trace!("[{}] heap stats: {:?}", kaspa_perf_monitor::SERVICE_NAME, dhat::HeapStats::get());
         };

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -1,6 +1,8 @@
-use kaspa_core::trace;
 use portable_atomic::{AtomicF64, AtomicUsize};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    fmt::Display,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 #[derive(Debug, Default)]
 pub(crate) struct Counters {
@@ -97,21 +99,22 @@ fn to_human_readable(mut number_to_format: f64, precision: usize, suffix: &str) 
     format!("{number_to_format:.precision$}{}{}", found_unit, suffix)
 }
 
-impl CountersSnapshot {
-    pub fn log_metrics(&self, service_name: &str) {
-        trace!(
-            "[{}] process metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage (per core): {}",
-            service_name,
+impl Display for CountersSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Performance Metrics")?;
+        writeln!(
+            f,
+            "Process Metrics: RSS: {} ({}), VIRT: {} ({}), cores: {}, cpu usage (per core): {}",
             self.resident_set_size,
             to_human_readable(self.resident_set_size as f64, 2, "B"),
             self.virtual_memory_size,
             to_human_readable(self.virtual_memory_size as f64, 2, "B"),
             self.core_num,
             self.cpu_usage
-        );
-        trace!(
-            "[{}] disk io metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
-            service_name,
+        )?;
+        write!(
+            f,
+            "Disk IO Metrics: FD: {}, read: {} ({}), write: {} ({}), read rate: {} ({}), write rate: {} ({})",
             self.fd_num,
             self.disk_io_read_bytes,
             to_human_readable(self.disk_io_read_bytes as f64, 0, "B"),
@@ -121,6 +124,6 @@ impl CountersSnapshot {
             to_human_readable(self.disk_io_read_per_sec, 0, "B/s"),
             self.disk_io_write_per_sec,
             to_human_readable(self.disk_io_write_per_sec, 0, "B/s")
-        );
+        )
     }
 }

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -140,7 +140,7 @@ fn main_impl(mut args: Args) {
         let ts = Arc::new(TickService::new());
 
         let cb = move |counters: CountersSnapshot| {
-            counters.log_metrics(kaspa_perf_monitor::SERVICE_NAME);
+            trace!("{}", counters);
             #[cfg(feature = "heap")]
             trace!("heap stats: {:?}", dhat::HeapStats::get());
         };

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -70,7 +70,7 @@ struct Args {
 
     /// Logging level for all subsystems {off, error, warn, info, debug, trace}
     ///  -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems
-    #[arg(long = "loglevel", default_value = format!("info,{}=trace,kaspa_perf_monitor::counters=trace", env!("CARGO_PKG_NAME")))]
+    #[arg(long = "loglevel", default_value = format!("info,{}=trace", env!("CARGO_PKG_NAME")))]
     log_level: String,
 
     /// Output directory to save the simulation DB


### PR DESCRIPTION
Perf Monitor will now log the data in two lines making it clearer and easier to read.

Two locations affected:
- simpa
- daemon.rs (when kaspad is run with `--perf-metrics`)

When running with `--perf-metrics` perf metric logs will now look like this:

```
2023-12-21 16:21:41.689-07:00 [TRACE] process metrics: RSS: 756514816 (756.51MB), VIRT: 420548624384 (420.55GB), cores: 16, cpu usage (per core): 6.5524591458119525
2023-12-21 16:21:41.690-07:00 [TRACE] disk io metrics: FD: 37, read: 438272 (438KB), write: 2047922176 (2GB), read rate: 2457.108578284343 (2KB/s), write rate: 68021774.845031 (68MB/s)
```

Sample run used here:
```
cargo run --release --bin simpa -- -t=200 -d=2 -b=8 -n=1000 --perf-metrics
```

and

```
cargo run --release --bin kaspad -- --utxoindex --perf-metrics
```