### PR TITLE
Prevent any hashfn other than poseidon2 + limit large VK

### DIFF
--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -897,7 +897,7 @@ opcode_list! {
             vm.consume_script_units(tag.cost())?;
 
             // Verify the ZK proof
-            verify_zk(tag, &mut vm.dstack)?;
+            verify_zk(tag, &mut vm.dstack, &mut vm.runtime_resource_meter)?;
 
             // If no errors, push true to the stack
             vm.dstack.push_item(true)?;

--- a/crypto/txscript/src/runtime_resource_meter.rs
+++ b/crypto/txscript/src/runtime_resource_meter.rs
@@ -103,9 +103,9 @@ impl RuntimeScriptUnitMeter {
                 Ok(())
             }
             None => {
-                let overflow = units - self.remaining_script_units;
-                let used_units = self.script_units_limit + overflow;
-                Err(TxScriptError::ExceededCommittedScriptUnits { used: used_units.0, limit: self.script_units_limit.0 })
+                let overflow = units.0 - self.remaining_script_units.0;
+                let used_units = self.script_units_limit.0.saturating_add(overflow);
+                Err(TxScriptError::ExceededCommittedScriptUnits { used: used_units, limit: self.script_units_limit.0 })
             }
         }
     }
@@ -207,6 +207,29 @@ mod tests {
         assert_eq!(meter.consume_sig_op_cost(1), Err(TxScriptError::ExceededCommittedScriptUnits { used: 300, limit: 250 }));
         assert_eq!(meter.used_sig_ops(), 2);
         assert_eq!(meter.used_script_units(), ScriptUnits(200));
+    }
+
+    #[test]
+    fn script_units_meter_saturates_exceeded_used_units() {
+        let mut meter = RuntimeScriptUnitMeter::new(ScriptUnits(0), ScriptUnits(100));
+
+        assert_eq!(meter.consume_script_units(ScriptUnits(60)), Ok(()));
+        assert_eq!(
+            meter.consume_script_units(ScriptUnits(u64::MAX)),
+            Err(TxScriptError::ExceededCommittedScriptUnits { used: u64::MAX, limit: 100 })
+        );
+        assert_eq!(meter.used_script_units(), ScriptUnits(60));
+    }
+
+    #[test]
+    fn script_units_meter_rejects_u64_max_charge_without_panicking() {
+        let mut meter = RuntimeScriptUnitMeter::new(ScriptUnits(0), ScriptUnits(100));
+
+        assert_eq!(
+            meter.consume_script_units(ScriptUnits(u64::MAX)),
+            Err(TxScriptError::ExceededCommittedScriptUnits { used: u64::MAX, limit: 100 })
+        );
+        assert_eq!(meter.used_script_units(), ScriptUnits(0));
     }
 
     #[test]

--- a/crypto/txscript/src/zk_precompiles/fields/error.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum FieldsError {
+    #[error("Invalid Fr length: expected 32 bytes, got {0}")]
+    InvalidLength(usize),
     #[error("ARK serialization error: {0}")]
     ArkSerialization(#[from] ark_serialize::SerializationError),
 }

--- a/crypto/txscript/src/zk_precompiles/fields/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/fields/mod.rs
@@ -19,10 +19,15 @@ impl Fr {
     }
 }
 
+pub const FR_BYTES: usize = 32;
+
 impl TryFrom<&[u8]> for Fr {
     type Error = FieldsError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != FR_BYTES {
+            return Err(FieldsError::InvalidLength(bytes.len()));
+        }
         Ok(Fr(ark_bn254::Fr::deserialize_uncompressed(bytes)?))
     }
 }
@@ -44,5 +49,36 @@ impl OpcodeData<Fr> for StackEntry {
         let mut bytes = Vec::new();
         from.0.serialize_uncompressed(&mut bytes).map_err(|_| SerializationError::ArkSerialization)?;
         Ok(SmallVec::from_vec(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FR_BYTES, Fr};
+    use crate::zk_precompiles::fields::error::FieldsError;
+
+    #[test]
+    fn fr_accepts_exactly_32_bytes() {
+        let mut bytes = [0u8; FR_BYTES];
+        bytes[0] = 0x01;
+        Fr::try_from(bytes.as_slice()).expect("32-byte in-range Fr must parse");
+    }
+
+    #[test]
+    fn fr_rejects_oversized_buffer() {
+        let oversized = vec![0u8; 64];
+        match Fr::try_from(oversized.as_slice()) {
+            Err(FieldsError::InvalidLength(64)) => {}
+            other => panic!("expected InvalidLength(64), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fr_rejects_undersized_buffer() {
+        let short = vec![0u8; 16];
+        match Fr::try_from(short.as_slice()) {
+            Err(FieldsError::InvalidLength(16)) => {}
+            other => panic!("expected InvalidLength(16), got {other:?}"),
+        }
     }
 }

--- a/crypto/txscript/src/zk_precompiles/groth16/error.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/error.rs
@@ -8,6 +8,8 @@ pub enum Groth16Error {
     VerificationFailed,
     #[error("Groth16 verifying key has empty gamma_abc_g1")]
     EmptyGammaAbc,
+    #[error("Groth16 verifying key bytes are too short to read gamma_abc_g1 length")]
+    MalformedVerifyingKey,
     #[error("Kaspa txscript error: {0}")]
     FromTxScript(#[from] kaspa_txscript_errors::TxScriptError),
     #[error("ARK serialization error: {0}")]

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -1,15 +1,28 @@
 mod error;
 use ark_bn254::Bn254;
 use ark_groth16::{Groth16, Proof, VerifyingKey};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::CanonicalDeserialize;
+use kaspa_consensus_core::mass::ScriptUnits;
 
 pub use error::Groth16Error;
 
 use crate::{
     data_stack::Stack,
     opcodes::i32s_to_usizes,
+    runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{ZkPrecompile, fields::Fr},
 };
+
+/// Byte offset of the gamma_abc_g1 length prefix inside a compressed BN254
+/// It consists of: alpha_g1 (32 bytes) + beta_g2 (64 bytes) + gamma_g2 (64 bytes) + delta_g2 (64 bytes)
+const VK_FIXED_PREFIX_LEN: usize = 32 + 64 * 3;
+
+/// Width of ark-serialize's Vec length prefix
+const GAMMA_ABC_G1_LEN_PREFIX_BYTES: usize = 8;
+
+/// Empirically determined script unit cost per gamma_abc_g1 element in the VK
+/// such that the total verification cost is within 10ms.
+pub const GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS: u64 = 60_000;
 
 pub struct Groth16Precompile;
 impl ZkPrecompile for Groth16Precompile {
@@ -17,7 +30,7 @@ impl ZkPrecompile for Groth16Precompile {
     /// Verifies the integrity of a Groth16 proof.
     ///
     /// *NOTE: Experimental code; not yet fully audited for mainnet use.* TODO(pre-covpp)
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error> {
         // Retrieve the uncompressed VK
         let [unprepared_compressed_key] = dstack.pop_raw()?;
 
@@ -36,6 +49,19 @@ impl ZkPrecompile for Groth16Precompile {
             // Convert bytes to Fr and add to public inputs
             unprepared_public_inputs.push(fr);
         }
+
+        // Charge per gamma_abc_g1 element before deserialization.
+        let len_bytes: [u8; GAMMA_ABC_G1_LEN_PREFIX_BYTES] = unprepared_compressed_key
+            .get(VK_FIXED_PREFIX_LEN..VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(Groth16Error::MalformedVerifyingKey)?;
+
+        let gamma_abc_element_count = u64::from_le_bytes(len_bytes);
+        let gamma_abc_cost = ScriptUnits(gamma_abc_element_count.saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
+
+        // Try consume and throw if we cant
+        meter.consume_script_units(gamma_abc_cost)?;
+
         // Deserialize verifying key
         let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
         if vk.gamma_abc_g1.is_empty() {
@@ -47,12 +73,9 @@ impl ZkPrecompile for Groth16Precompile {
         // Deserialize proof
         let proof: &Proof<ark_ec::bn::Bn<ark_bn254::Config>> = &Proof::deserialize_compressed(&*proof_bytes)?;
 
-        let mut encoded_prepared_inputs = Vec::new();
-
         // Prepare public inputs with the prepared verifying key
         let prepared_inputs =
             Groth16::<Bn254>::prepare_inputs(&pvk, &unprepared_public_inputs.iter().map(|x| *x.field()).collect::<Vec<_>>())?;
-        prepared_inputs.serialize_compressed(&mut encoded_prepared_inputs)?;
 
         // Verify the proof with the prepared inputs
         if Groth16::<Bn254>::verify_proof_with_prepared_inputs(&pvk, proof, &prepared_inputs)? {
@@ -65,11 +88,98 @@ impl ZkPrecompile for Groth16Precompile {
 
 #[cfg(test)]
 mod tests {
+    use super::{GAMMA_ABC_G1_LEN_PREFIX_BYTES, GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS, Groth16Error, VK_FIXED_PREFIX_LEN};
     use crate::{
         data_stack::Stack,
         hex,
+        runtime_resource_meter::RuntimeResourceMeter,
         zk_precompiles::{ZkPrecompile, groth16::Groth16Precompile},
     };
+    use ark_bn254::{Bn254, G1Affine, G2Affine};
+    use ark_groth16::VerifyingKey;
+    use ark_serialize::{CanonicalSerialize, Compress};
+    use kaspa_consensus_core::mass::ScriptUnits;
+    use kaspa_txscript_errors::TxScriptError;
+
+    #[test]
+    fn check_sizes() {
+        assert_eq!(G1Affine::default().serialized_size(Compress::Yes), 32);
+        assert_eq!(G2Affine::default().serialized_size(Compress::Yes), 64);
+    }
+
+    #[test]
+    fn check_vec_prefix() {
+        let v: Vec<u8> = vec![];
+        let mut buf = Vec::new();
+        v.serialize_compressed(&mut buf).unwrap();
+        assert_eq!(buf.len(), 8); // empty Vec serializes to just the length prefix
+        assert_eq!(buf, [0u8; 8]); // length 0 as LE u64
+
+        let v: Vec<u8> = vec![0xAA];
+        let mut buf = Vec::new();
+        v.serialize_compressed(&mut buf).unwrap();
+        assert_eq!(&buf[..8], &[1, 0, 0, 0, 0, 0, 0, 0]); // length 1 LE u64
+        assert_eq!(buf[8], 0xAA);
+    }
+
+    /// Build a synthetic VK with a known `gamma_abc_g1.len()`, serialize it,
+    /// and confirm our offset-based reader extracts the same count without
+    /// depending on a hand-rolled hex fixture.
+    fn vk_with_gamma_abc_count(count: usize) -> Vec<u8> {
+        let vk = VerifyingKey::<Bn254> {
+            alpha_g1: G1Affine::default(),
+            beta_g2: G2Affine::default(),
+            gamma_g2: G2Affine::default(),
+            delta_g2: G2Affine::default(),
+            gamma_abc_g1: vec![G1Affine::default(); count],
+        };
+        let mut bytes = Vec::new();
+        vk.serialize_compressed(&mut bytes).expect("serialize VK");
+        bytes
+    }
+
+    #[test]
+    fn verify_zk_rejects_oversized_vk_via_meter() {
+        const PER_INPUT_BUDGET: ScriptUnits = ScriptUnits(50_000_000);
+        for &count in &[1_000usize, 10_000, 30_000] {
+            let vk_bytes = vk_with_gamma_abc_count(count);
+
+            let mut stack = Stack::new(Vec::new(), true);
+            stack.push_item(0i32).unwrap(); // n_inputs = 0
+            stack.push(vec![0u8; 128].into()).unwrap(); // dummy proof , but we should throw earlier
+            stack.push(vk_bytes.into()).unwrap();
+
+            let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), PER_INPUT_BUDGET);
+
+            let expected_charge = (count as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
+            assert!(
+                expected_charge > PER_INPUT_BUDGET.0,
+                "gamma_abc charge {expected_charge} must exceed budget {}",
+                PER_INPUT_BUDGET.0
+            );
+
+            let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("oversized VK must be rejected");
+            match err {
+                Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
+                    assert_eq!(limit, PER_INPUT_BUDGET.0);
+                    assert_eq!(used, PER_INPUT_BUDGET.0 + (expected_charge - PER_INPUT_BUDGET.0));
+                }
+                other => panic!("expected ExceededCommittedScriptUnits for gamma_abc_g1 element count = {count}, got: {other:?}"),
+            }
+        }
+    }
+
+    /// validate that abc g1 length is at the offset we expect it is
+    #[test]
+    fn gamma_abc_g1_length_prefix_lives_at_expected_offset() {
+        for &count in &[0usize, 1, 5, 6, 42] {
+            let bytes = vk_with_gamma_abc_count(count);
+            assert!(bytes.len() >= VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES);
+            let len_slice: [u8; GAMMA_ABC_G1_LEN_PREFIX_BYTES] =
+                bytes[VK_FIXED_PREFIX_LEN..VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES].try_into().unwrap();
+            assert_eq!(u64::from_le_bytes(len_slice), count as u64, "mismatch for expected gamma_abc_g1 element count = {count}");
+        }
+    }
 
     #[test]
     fn try_verify_stack() {
@@ -92,6 +202,7 @@ mod tests {
         stack.push_item(5i32).unwrap(); // Number of public inputs
         stack.push(proof.into()).unwrap();
         stack.push(unprepared_compressed_vk.into()).unwrap();
-        Groth16Precompile::verify_zk(&mut stack).unwrap();
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(u64::MAX));
+        Groth16Precompile::verify_zk(&mut stack, &mut meter).unwrap();
     }
 }

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -64,9 +64,15 @@ impl ZkPrecompile for Groth16Precompile {
 
         // Deserialize verifying key
         let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
+
         if vk.gamma_abc_g1.is_empty() {
             return Err(Groth16Error::EmptyGammaAbc);
         }
+
+        if unprepared_public_inputs.len() + 1 != vk.gamma_abc_g1.len() {
+            return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
+        }
+
         // Prepare verifying key
         let pvk = ark_groth16::prepare_verifying_key(&vk);
 

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -66,7 +66,7 @@ impl ZkPrecompile for Groth16Precompile {
             return Err(Groth16Error::EmptyGammaAbc);
         }
 
-        // +1 over an actual array len cannot overflow
+        // +1 over an actual array len cannot overflow since the max array len is usize::MAX - 1
         if unprepared_public_inputs.len() + 1 != gamma_abc_element_count {
             return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
         }

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -122,9 +122,6 @@ mod tests {
         assert_eq!(buf[8], 0xAA);
     }
 
-    /// Build a synthetic VK with a known `gamma_abc_g1.len()`, serialize it,
-    /// and confirm our offset-based reader extracts the same count without
-    /// depending on a hand-rolled hex fixture.
     fn vk_with_gamma_abc_count(count: usize) -> Vec<u8> {
         let vk = VerifyingKey::<Bn254> {
             alpha_g1: G1Affine::default(),

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -66,7 +66,7 @@ impl ZkPrecompile for Groth16Precompile {
         }
 
         // Public inputs are stack-depth bounded, so +1 cannot overflow.
-        if (unprepared_public_inputs.len() + 1) as u64 != gamma_abc_element_count {
+        if unprepared_public_inputs.len() as u64 + 1 != gamma_abc_element_count {
             return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
         }
 

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -58,29 +58,28 @@ impl ZkPrecompile for Groth16Precompile {
             .and_then(|s| s.try_into().ok())
             .ok_or(Groth16Error::MalformedVerifyingKey)?;
 
-        let gamma_abc_element_count =
-            usize::try_from(u64::from_le_bytes(len_bytes)).map_err(|_| Groth16Error::MalformedVerifyingKey)?;
+        let gamma_abc_element_count = u64::from_le_bytes(len_bytes);
 
         // Covered by the following count check but kept for clearer error
         if gamma_abc_element_count == 0 {
             return Err(Groth16Error::EmptyGammaAbc);
         }
 
-        // +1 over an actual array len cannot overflow since the max array len is usize::MAX - 1
-        if unprepared_public_inputs.len() + 1 != gamma_abc_element_count {
+        // Public inputs are stack-depth bounded, so +1 cannot overflow.
+        if (unprepared_public_inputs.len() + 1) as u64 != gamma_abc_element_count {
             return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
         }
 
-        let gamma_abc_cost = ScriptUnits((gamma_abc_element_count as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
+        let gamma_abc_cost = ScriptUnits(gamma_abc_element_count.saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
 
-        // Try consume and err if we cant
+        // Try consuming the vk cost and err if we are over the limit
         meter.consume_script_units(gamma_abc_cost)?;
 
         // Deserialize verifying key
         let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
 
-        // Over-defensive double check that the number of args matches the same parsed count.
-        if unprepared_public_inputs.len() + 1 != vk.gamma_abc_g1.len() {
+        // Over-defensive double check that the deserialized vk has the expected gamma_abc_g1 count.
+        if gamma_abc_element_count != vk.gamma_abc_g1.len() as u64 {
             return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
         }
 

--- a/crypto/txscript/src/zk_precompiles/groth16/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/groth16/mod.rs
@@ -43,7 +43,9 @@ impl ZkPrecompile for Groth16Precompile {
         // Retrieve public inputs
         let mut unprepared_public_inputs = Vec::new();
 
-        // For each public input, pop from the stack and convert to Fr
+        // For each public input, pop from the stack and convert to Fr.
+        //
+        // Note: public input count is bounded by the script stack depth limit.
         for _ in 0..n_inputs {
             let [fr] = dstack.pop_items::<1, Fr>()?;
             // Convert bytes to Fr and add to public inputs
@@ -56,19 +58,28 @@ impl ZkPrecompile for Groth16Precompile {
             .and_then(|s| s.try_into().ok())
             .ok_or(Groth16Error::MalformedVerifyingKey)?;
 
-        let gamma_abc_element_count = u64::from_le_bytes(len_bytes);
-        let gamma_abc_cost = ScriptUnits(gamma_abc_element_count.saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
+        let gamma_abc_element_count =
+            usize::try_from(u64::from_le_bytes(len_bytes)).map_err(|_| Groth16Error::MalformedVerifyingKey)?;
 
-        // Try consume and throw if we cant
+        // Covered by the following count check but kept for clearer error
+        if gamma_abc_element_count == 0 {
+            return Err(Groth16Error::EmptyGammaAbc);
+        }
+
+        // +1 over an actual array len cannot overflow
+        if unprepared_public_inputs.len() + 1 != gamma_abc_element_count {
+            return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
+        }
+
+        let gamma_abc_cost = ScriptUnits((gamma_abc_element_count as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS));
+
+        // Try consume and err if we cant
         meter.consume_script_units(gamma_abc_cost)?;
 
         // Deserialize verifying key
         let vk = VerifyingKey::deserialize_compressed(&*unprepared_compressed_key)?;
 
-        if vk.gamma_abc_g1.is_empty() {
-            return Err(Groth16Error::EmptyGammaAbc);
-        }
-
+        // Over-defensive double check that the number of args matches the same parsed count.
         if unprepared_public_inputs.len() + 1 != vk.gamma_abc_g1.len() {
             return Err(ark_relations::gr1cs::SynthesisError::ArityMismatch.into());
         }
@@ -103,7 +114,7 @@ mod tests {
     };
     use ark_bn254::{Bn254, G1Affine, G2Affine};
     use ark_groth16::VerifyingKey;
-    use ark_serialize::{CanonicalSerialize, Compress};
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress};
     use kaspa_consensus_core::mass::ScriptUnits;
     use kaspa_txscript_errors::TxScriptError;
 
@@ -142,33 +153,49 @@ mod tests {
     }
 
     #[test]
-    fn verify_zk_rejects_oversized_vk_via_meter() {
-        const PER_INPUT_BUDGET: ScriptUnits = ScriptUnits(50_000_000);
-        for &count in &[1_000usize, 10_000, 30_000] {
-            let vk_bytes = vk_with_gamma_abc_count(count);
+    fn verify_zk_rejects_arity_mismatch_before_meter_charge() {
+        let vk_bytes = vk_with_gamma_abc_count(5);
 
-            let mut stack = Stack::new(Vec::new(), true);
-            stack.push_item(0i32).unwrap(); // n_inputs = 0
-            stack.push(vec![0u8; 128].into()).unwrap(); // dummy proof , but we should throw earlier
-            stack.push(vk_bytes.into()).unwrap();
+        let mut stack = Stack::new(Vec::new(), true);
+        stack.push_item(0i32).unwrap();
+        stack.push(vec![0u8; 128].into()).unwrap();
+        stack.push(vk_bytes.into()).unwrap();
 
-            let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), PER_INPUT_BUDGET);
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), ScriptUnits(0));
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("arity mismatch must be rejected");
+        match err {
+            Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch) => {}
+            other => panic!("expected ArityMismatch before meter charge, got: {other:?}"),
+        }
+        assert_eq!(meter.used_script_units(), ScriptUnits(0));
+    }
 
-            let expected_charge = (count as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
-            assert!(
-                expected_charge > PER_INPUT_BUDGET.0,
-                "gamma_abc charge {expected_charge} must exceed budget {}",
-                PER_INPUT_BUDGET.0
-            );
+    #[test]
+    fn verify_zk_rejects_over_budget_vk_via_meter() {
+        const PER_INPUT_BUDGET: ScriptUnits = ScriptUnits(200_000);
+        const COUNT: usize = 5;
+        let vk_bytes = vk_with_gamma_abc_count(COUNT);
 
-            let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("oversized VK must be rejected");
-            match err {
-                Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
-                    assert_eq!(limit, PER_INPUT_BUDGET.0);
-                    assert_eq!(used, PER_INPUT_BUDGET.0 + (expected_charge - PER_INPUT_BUDGET.0));
-                }
-                other => panic!("expected ExceededCommittedScriptUnits for gamma_abc_g1 element count = {count}, got: {other:?}"),
+        let mut stack = Stack::new(Vec::new(), true);
+        for _ in 0..COUNT - 1 {
+            stack.push(vec![0u8; 32].into()).unwrap();
+        }
+        stack.push_item((COUNT - 1) as i32).unwrap();
+        stack.push(vec![0u8; 128].into()).unwrap();
+        stack.push(vk_bytes.into()).unwrap();
+
+        let mut meter = RuntimeResourceMeter::new_script_units(ScriptUnits(0), PER_INPUT_BUDGET);
+
+        let expected_charge = (COUNT as u64).saturating_mul(GROTH16_GAMMA_ABC_G1_ELEMENT_SCRIPT_UNITS);
+        assert!(expected_charge > PER_INPUT_BUDGET.0, "gamma_abc charge {expected_charge} must exceed budget {}", PER_INPUT_BUDGET.0);
+
+        let err = Groth16Precompile::verify_zk(&mut stack, &mut meter).expect_err("over-budget VK must be rejected");
+        match err {
+            Groth16Error::FromTxScript(TxScriptError::ExceededCommittedScriptUnits { used, limit }) => {
+                assert_eq!(limit, PER_INPUT_BUDGET.0);
+                assert_eq!(used, expected_charge);
             }
+            other => panic!("expected ExceededCommittedScriptUnits for gamma_abc_g1 element count = {COUNT}, got: {other:?}"),
         }
     }
 
@@ -182,6 +209,29 @@ mod tests {
                 bytes[VK_FIXED_PREFIX_LEN..VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES].try_into().unwrap();
             assert_eq!(u64::from_le_bytes(len_slice), count as u64, "mismatch for expected gamma_abc_g1 element count = {count}");
         }
+    }
+
+    #[test]
+    fn ark_vk_deserialize_reads_gamma_abc_g1_len_from_expected_offset() {
+        // The precompile meters large VKs by reading the Ark-serialized
+        // gamma_abc_g1 Vec length before deserializing the VK. This locks that
+        // our offset is the same length prefix Ark later uses for deserialization.
+        let mut two_elem_bytes = vk_with_gamma_abc_count(5);
+        let two_elem_len =
+            VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES + 2 * G1Affine::default().serialized_size(Compress::Yes);
+        two_elem_bytes[VK_FIXED_PREFIX_LEN..VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES].copy_from_slice(&2u64.to_le_bytes());
+        two_elem_bytes.truncate(two_elem_len);
+
+        let vk =
+            VerifyingKey::<Bn254>::deserialize_compressed(&*two_elem_bytes).expect("Ark should deserialize two gamma_abc_g1 elements");
+
+        assert_eq!(vk.gamma_abc_g1.len(), 2);
+
+        let mut five_elem_prefix_with_two_elems = two_elem_bytes;
+        five_elem_prefix_with_two_elems[VK_FIXED_PREFIX_LEN..VK_FIXED_PREFIX_LEN + GAMMA_ABC_G1_LEN_PREFIX_BYTES]
+            .copy_from_slice(&5u64.to_le_bytes());
+        VerifyingKey::<Bn254>::deserialize_compressed(&*five_elem_prefix_with_two_elems)
+            .expect_err("Ark should reject when the prefix asks for five gamma_abc_g1 elements but only two are present");
     }
 
     #[test]

--- a/crypto/txscript/src/zk_precompiles/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/mod.rs
@@ -6,6 +6,7 @@ pub mod tags;
 pub mod tests;
 use crate::{
     data_stack::Stack,
+    runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{error::ZkIntegrityError, groth16::Groth16Precompile, risc0::R0SuccinctPrecompile, tags::ZkTag},
 };
 use kaspa_consensus_core::mass::ScriptUnits;
@@ -13,7 +14,7 @@ use kaspa_txscript_errors::TxScriptError;
 
 trait ZkPrecompile {
     type Error: Into<ZkIntegrityError> + std::fmt::Display;
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error>;
+    fn verify_zk(dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error>;
 }
 
 pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
@@ -29,11 +30,11 @@ pub(crate) fn parse_tag(dstack: &mut Stack) -> Result<ZkTag, TxScriptError> {
  * Verifies a ZK proof from the data stack.
  * The first byte on the stack indicates the ZK tag (proof type).
  */
-pub(crate) fn verify_zk(tag: ZkTag, dstack: &mut Stack) -> Result<(), TxScriptError> {
+pub(crate) fn verify_zk(tag: ZkTag, dstack: &mut Stack, meter: &mut RuntimeResourceMeter) -> Result<(), TxScriptError> {
     // Match the tag and verify the proof accordingly
     match tag {
-        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
-        ZkTag::R0Succinct => R0SuccinctPrecompile::verify_zk(dstack).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
+        ZkTag::Groth16 => Groth16Precompile::verify_zk(dstack, meter).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
+        ZkTag::R0Succinct => R0SuccinctPrecompile::verify_zk(dstack, meter).map_err(|e| TxScriptError::ZkIntegrity(e.to_string())),
     }
 }
 

--- a/crypto/txscript/src/zk_precompiles/risc0/error.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/error.rs
@@ -2,6 +2,8 @@ use kaspa_txscript_errors::TxScriptError;
 use risc0_zkp::verify::VerificationError;
 use thiserror::Error;
 
+use crate::zk_precompiles::risc0::rcpt::HashFnId;
+
 #[derive(Debug, Error)]
 pub enum R0Error {
     #[error("Std io error: {0}")]
@@ -22,6 +24,8 @@ pub enum R0Error {
     InvalidHashFnEncoding(usize),
     #[error("Invalid hash function id: {0}")]
     InvalidHashFnId(u8),
+    #[error("Unsupported hash function: {0:?}")]
+    UnsupportedHashFn(HashFnId),
     #[error("Verification failed")]
     VerificationFailed,
     #[error("Merkle proof verification failed")]

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -10,7 +10,6 @@ use crate::{
         },
     },
 };
-use kaspa_txscript_errors::TxScriptError;
 use risc0_zkp::core::digest::DIGEST_BYTES;
 pub use risc0_zkp::core::digest::Digest;
 mod error;
@@ -116,7 +115,7 @@ impl ZkPrecompile for R0SuccinctPrecompile {
         // If we were to bypass the compute_assert_claim step, then an attacker could modify the claim in the receipt
         // to match whatever they want and just providing some arbitrary proof. This is why this step is crucial.
         // As this step binds that the provided image id and journal are indeed the ones that were used to generate the proof.
-        compute_assert_claim(rcpt.claim(), image_id, journal).map_err(|e| TxScriptError::ZkIntegrity(e.to_string()))?;
+        compute_assert_claim(rcpt.claim(), image_id, journal)?;
 
         Ok(())
     }

--- a/crypto/txscript/src/zk_precompiles/risc0/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/risc0/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     data_stack::Stack,
+    runtime_resource_meter::RuntimeResourceMeter,
     zk_precompiles::{
         ZkPrecompile,
         risc0::{
@@ -80,13 +81,19 @@ impl ZkPrecompile for R0SuccinctPrecompile {
     /// - control inclusion proof digests (bytes)
     /// - control index (bytes, u32 le)
     /// - claim (bytes)
-    fn verify_zk(dstack: &mut Stack) -> Result<(), Self::Error> {
+    fn verify_zk(dstack: &mut Stack, _meter: &mut RuntimeResourceMeter) -> Result<(), Self::Error> {
         let [claim, control_index, control_digests, seal, journal, image_id, control_id, hashfn] = dstack.pop_raw()?;
 
         let control_id = parse_digest(control_id)?;
         let seal = parse_seal(seal)?;
         let claim = parse_digest(claim)?;
         let hashfn = parse_hashfn(hashfn)?;
+
+        // For now we only support the poseidon2 hashfn
+        if hashfn != HashFnId::Poseidon2 {
+            return Err(R0Error::UnsupportedHashFn(hashfn));
+        }
+
         let control_index = parse_merkle_index(control_index)?;
         let control_digests = parse_digest_list(control_digests)?;
         let control_inclusion_proof = MerkleProof { index: control_index, digests: control_digests };

--- a/crypto/txscript/src/zk_precompiles/tests/mod.rs
+++ b/crypto/txscript/src/zk_precompiles/tests/mod.rs
@@ -54,6 +54,15 @@ mod fast_zk_tests {
         }
     }
 
+    fn expect_groth16_arity_mismatch(result: Result<(), TxScriptError>, case: &str) {
+        let expected = Groth16Error::ArkR1CS(ark_relations::gr1cs::SynthesisError::ArityMismatch).to_string();
+        match result {
+            Err(TxScriptError::ZkIntegrity(e)) if e == expected => {}
+            Err(e) => panic!("{case}: expected Groth16 arity mismatch, got {e:?}"),
+            Ok(_) => panic!("{case}: expected Groth16 arity mismatch, got success"),
+        }
+    }
+
     #[test]
     fn test_groth16_fast() {
         let script = build_groth_script();
@@ -86,29 +95,25 @@ mod fast_zk_tests {
     }
 
     #[test]
-    fn verify_groth16_missing_public_input_fails_verification() {
+    fn verify_groth16_missing_public_input_rejected() {
         let (vk, proof, mut inputs) = load_groth_fields();
         inputs.pop();
         let script = build_groth_script_from_fields(&vk, &proof, &inputs);
         let cache = Cache::new(0);
         let reused_values = SigHashReusedValuesUnsync::new();
 
-        match execute_zk_script(&script, &cache, &reused_values) {
-            Err(TxScriptError::ZkIntegrity(e)) if e == Groth16Error::VerificationFailed.to_string() => {}
-            Err(e) => panic!("expected Groth16 verification failure, got {e:?}"),
-            Ok(_) => panic!("missing public input should fail verification"),
-        }
+        expect_groth16_arity_mismatch(execute_zk_script(&script, &cache, &reused_values), "missing public input");
     }
 
     #[test]
-    fn verify_groth16_extra_public_input_currently_accepted() {
+    fn verify_groth16_extra_public_input_rejected() {
         let (vk, proof, mut inputs) = load_groth_fields();
         inputs.push(inputs[0].clone());
         let script = build_groth_script_from_fields(&vk, &proof, &inputs);
         let cache = Cache::new(0);
         let reused_values = SigHashReusedValuesUnsync::new();
 
-        execute_zk_script(&script, &cache, &reused_values).unwrap();
+        expect_groth16_arity_mismatch(execute_zk_script(&script, &cache, &reused_values), "extra public input");
     }
 
     #[test]


### PR DESCRIPTION
- Prevents usage of any other hashfn other than poseidon2 due to limited support on r0 (preventative measure)
- Prevent usage of large VK in invalid/valid execution of Groth16 tagged zk precompile by consuming script units.
- Remove unnecessary serialization